### PR TITLE
Display better table

### DIFF
--- a/override/override.css
+++ b/override/override.css
@@ -1,3 +1,7 @@
 .Card {
   box-shadow: none !important;
 }
+
+[data-testid="embed-frame"] [data-testid="column-header"], [data-testid="embed-frame"] [data-testid="legend-caption"] {
+  display: none;
+}


### PR DESCRIPTION
Before
![image](https://github.com/moka-care/metabase-buildpack/assets/1119578/008eef8b-cd24-427e-aaec-83a9689d99a7)

After
![Screenshot 2024-05-21 at 11 53 01](https://github.com/moka-care/metabase-buildpack/assets/1119578/3521237b-38d7-4552-a1c7-58588f08cb5e)
